### PR TITLE
Added type check before casting

### DIFF
--- a/YouboraLib/comm/YBRequest.m
+++ b/YouboraLib/comm/YBRequest.m
@@ -160,7 +160,7 @@ static NSMutableArray<YBRequestErrorBlock> * everyErrorListenerList;
                 return;
             }
             
-            if(response != nil) {
+            if(response != nil && [response isKindOfClass:[NSHTTPURLResponse class]]) {
                 NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
                 [YBLog debug:[NSString stringWithFormat:@"Response code for: %@ %ld",weakSelf.service, (long)httpResponse.statusCode]];
             }


### PR DESCRIPTION
This PR brings fix for unexpected crash. 

## Description
When you're trying to request file with Youbora on iOS 13.3 and lower it works well. But whether requesting same file on iOS 13.4 and higher it makes application to crash.
So it happens due to "force casting" `NSURLResponse` to `NSHTTPURLResponse`. Seems that something has changed in iOS' Networking layer, because sometimes it returns regular `NSURLResponse` objects.

Here some exampes:
```
(lldb) po request.URL
file:///Users/vkondrashkov/Library/Developer/CoreSimulator/Devices/*/fallback.mp4
```

```
(lldb) po response
<NSURLResponse: 0x6000002e6000> { URL: file:///Users/vkondrashkov/Library/Developer/CoreSimulator/Devices/*/fallback.mp4 }
```

## Solution
Solution for this issue is pretty simple: add type checking before casting:
```objective-c
if(response != nil && [response isKindOfClass:[NSHTTPURLResponse class]]) {
    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
    /* ... */
}
```